### PR TITLE
chore: remove node_modules from clean scripts

### DIFF
--- a/sugar/react/package.json
+++ b/sugar/react/package.json
@@ -28,7 +28,7 @@
     "build": "pnpm run build:lib && pnpm run build:example",
     "build:example": "vite build",
     "build:lib": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/sugar/storybook/package.json
+++ b/sugar/storybook/package.json
@@ -21,7 +21,7 @@
     "build": "pnpm run build:tailwindcss && pnpm run build:storybook",
     "build:storybook": "storybook build",
     "build:tailwindcss": "tailwind -i ./src/tailwind.css -o ./public/tailwind.css",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "concurrently \"pnpm:dev:*\"",
     "dev:storybook": "storybook dev -p 6006",
     "dev:tailwindcss": "nodemon --watch src -e css --exec \"tailwind -i ./src/tailwind.css -o ./public/tailwind.css && nodetouch ./.storybook/preview-head.html\"",

--- a/sugar/sugar/package.json
+++ b/sugar/sugar/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/sugar/tailwind-helpers/package.json
+++ b/sugar/tailwind-helpers/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/sugar/tailwind-plugin-buttons/package.json
+++ b/sugar/tailwind-plugin-buttons/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/sugar/tailwind-plugin-form/package.json
+++ b/sugar/tailwind-plugin-form/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/sugar/tokens/package.json
+++ b/sugar/tokens/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",
     "postpublish": "rm -rf ./package",

--- a/tools/plop-generators/package.json
+++ b/tools/plop-generators/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup --publicDir",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",
     "postpublish": "rm -rf ./package",

--- a/tools/plop-generators/public/templates/skeleton/package.json.hbs
+++ b/tools/plop-generators/public/templates/skeleton/package.json.hbs
@@ -26,7 +26,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",
     "prepare": "tsup",

--- a/tools/postcss-config/package.json
+++ b/tools/postcss-config/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/tools/prettier-config/package.json
+++ b/tools/prettier-config/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "dev": "tsup --watch",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",

--- a/tools/test-utils/package.json
+++ b/tools/test-utils/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "analyze": "size-limit --why",
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf .turbo dist",
     "lint": "eslint --format stylish --max-warnings 0 --cache .",
     "lint:fix": "nr lint --fix",
     "prepare": "tsup",


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Remove `node_modules` from the `clean` scripts in all `package.json`s.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Running `clean` previously could brick local installs due to following symlinks.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a changeset via `pnpm run changeset` if my changes should be released.
