### PR TITLE
chore: improve plop package generation

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - sugar/*
   - tools/*
+  - playground

--- a/tools/plop-generators/public/templates/skeleton/package.json.hbs
+++ b/tools/plop-generators/public/templates/skeleton/package.json.hbs
@@ -40,13 +40,7 @@
   "devDependencies": {
     "@singlestone/eslint-config-sugar": "workspace:*",
     "@singlestone/prettier-config-sugar": "workspace:*",
-    "@singlestone/tsup-config": "workspace:*",
-    "@size-limit/preset-small-lib": "8.2.4",
-    "@types/node": "18.11.18",
-    "delete-publishconfig-directory": "1.0.0",
-    "size-limit": "8.2.4",
-    "tsup": "6.6.3",
-    "vitest": "0.28.5"
+    "@singlestone/tsup-config": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/tools/plop-generators/src/actions/index.ts
+++ b/tools/plop-generators/src/actions/index.ts
@@ -1,1 +1,1 @@
-export * from "./install-dependencies";
+export * from "./pnpm-install";

--- a/tools/plop-generators/src/actions/pnpm-install.ts
+++ b/tools/plop-generators/src/actions/pnpm-install.ts
@@ -23,15 +23,29 @@ const spawn = (cmd: string, args: readonly string[], options: SpawnOptions) =>
     });
   });
 
-export const installDependencies: CustomActionFunction = (
-  answers
+export const pnpmInstall: CustomActionFunction = (
+  answers,
+  config
 ): Promise<string> => {
   const cwd = join(process.cwd(), answers.packageType, answers.packageName);
-  return spawn(
-    /^win/.test(process.platform) ? "pnpm.cmd" : "pnpm",
-    ["install"],
-    { cwd, stdio: "inherit" }
-  )
+  const args = ["install"];
+  if (config.dev) {
+    args.push("-D");
+  }
+  if (config.exact) {
+    args.push("-E");
+  }
+  if (config.dependencies) {
+    if (Array.isArray(config.dependencies)) {
+      args.push(...config.dependencies);
+    } else {
+      return Promise.reject('"dependencies" must be an array');
+    }
+  }
+  return spawn(/^win/.test(process.platform) ? "pnpm.cmd" : "pnpm", args, {
+    cwd,
+    stdio: "inherit",
+  })
     .then(() => "successfully installed dependencies")
     .catch((err) => `error installing dependencies: ${err}`);
 };

--- a/tools/plop-generators/src/generators/skeleton.ts
+++ b/tools/plop-generators/src/generators/skeleton.ts
@@ -1,4 +1,4 @@
-import { PlopGeneratorConfig } from "node-plop";
+import { CustomActionConfig, PlopGeneratorConfig } from "node-plop";
 import { join } from "path";
 
 const resolveTemplateFile = (...fileNameParts: string[]) =>
@@ -93,7 +93,17 @@ export const skeleton: PlopGeneratorConfig = {
       templateFile: resolveTemplateFile("src", "sum.test.ts.hbs"),
     },
     {
-      type: "installDependencies",
-    },
+      type: "pnpmInstall",
+      dev: true,
+      exact: true,
+      dependencies: [
+        "@size-limit/preset-small-lib",
+        "@types/node",
+        "delete-publishconfig-directory",
+        "size-limit",
+        "tsup",
+        "vitest",
+      ],
+    } as CustomActionConfig<"pnpmInstall">,
   ],
 };

--- a/tools/plop-generators/src/index.ts
+++ b/tools/plop-generators/src/index.ts
@@ -1,10 +1,10 @@
 import { NodePlopAPI } from "plop";
 
-import { installDependencies } from "./actions";
+import { pnpmInstall } from "./actions";
 import { skeleton } from "./generators";
 
 export const plopGeneratorsSugar = (plop: NodePlopAPI): void => {
   plop.setDefaultInclude({ actionTypes: true, generators: true });
-  plop.setActionType("installDependencies", installDependencies);
+  plop.setActionType("pnpmInstall", pnpmInstall);
   plop.setGenerator("skeleton", skeleton);
 };


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Update the `plop-generators` pnpm installer to install specific dependencies not contained in the package.json. This will
always default to the latest exact version of the package with how it's currently configured. The packages in the bundled
package.json are internal packages that don't specify a version due to using the `workspace` protocol.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

`plop-generators` dependencies fall out of date easily due to it not being able to be scanned by Renovate.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran it locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a changeset via `pnpm run changeset` if my changes should be released.
