### PR TITLE
fix: add resize of none to textarea styles

### DIFF
--- a/sugar/react/example/App.tsx
+++ b/sugar/react/example/App.tsx
@@ -8,7 +8,7 @@ import { InputPanel } from "./panels/Input";
 import { RadioGroupPanel } from "./panels/RadioGroup";
 import { SelectPanel } from "./panels/Select";
 import { SideBySidePanel } from "./panels/SideBySide";
-import { TextareaPanel } from "./panels/Textarea";
+import { TextareaPanel } from "./panels/TextArea";
 
 export const App = () => (
   <div className="flex flex-col min-h-screen">

--- a/sugar/react/example/panels/TextArea.tsx
+++ b/sugar/react/example/panels/TextArea.tsx
@@ -7,7 +7,11 @@ export const TextareaPanel = () => {
       <PanelHeading>Textarea</PanelHeading>
       <PanelBody itemAlignment="start">
         <Label htmlFor="example-textarea">Textarea</Label>
-        <TextArea id="example-textarea" placeholder="Placeholder value" rows={10} />
+        <TextArea
+          id="example-textarea"
+          placeholder="Placeholder value"
+          rows={10}
+        />
       </PanelBody>
     </PanelRoot>
   );

--- a/sugar/react/example/panels/Textarea.tsx
+++ b/sugar/react/example/panels/Textarea.tsx
@@ -7,11 +7,7 @@ export const TextareaPanel = () => {
       <PanelHeading>Textarea</PanelHeading>
       <PanelBody itemAlignment="start">
         <Label htmlFor="example-textarea">Textarea</Label>
-        <TextArea
-          className="resize-none"
-          id="example-textarea"
-          placeholder="Placeholder value"
-        />
+        <TextArea id="example-textarea" placeholder="Placeholder value" rows={10} />
       </PanelBody>
     </PanelRoot>
   );

--- a/sugar/tailwind-plugin-form/src/inputs/inputs.styles.ts
+++ b/sugar/tailwind-plugin-form/src/inputs/inputs.styles.ts
@@ -35,12 +35,21 @@ export const inputBase = (theme: PluginAPI["theme"]): CSSRuleObject => {
 };
 
 export const textArea = (theme: PluginAPI["theme"]): CSSRuleObject => {
-  const base = { ...textInput(theme) };
+  const base = textInput(theme);
   // set the minimum height to the base height of an input
-  base["min-height"] = base["height"];
+  base.minHeight = base.height;
   // textarea height is provided by the `rows` attribute
   delete base["height"];
-  return base;
+
+  // we overwrite the padding shortly anyway
+  delete base["paddingLeft"];
+  delete base["padding"];
+
+  return {
+    ...base,
+    padding: `${theme("spacing")?.[1.5]} ${theme("spacing.3")} 0`,
+    resize: "none",
+  };
 };
 
 export const textInput = (theme: PluginAPI["theme"]): CSSRuleObject => ({


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Make some changes based on Kevin's feedback on the initial version of `textarea`s.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Kevin provided feedback in Slack about the padding.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/1672786/222824739-afd1d812-3968-488c-b444-18c97d4f3103.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a changeset via `pnpm run changeset` if my changes should be released.
